### PR TITLE
Fix correlated column removal and copy notebook

### DIFF
--- a/modules/final_preprocessing.py
+++ b/modules/final_preprocessing.py
@@ -113,7 +113,7 @@ def prepare_final_dataset(
     # drop_correlated_duplicates doit gérer target_col=None sans erreur !
     df_reduced, _, _ = drop_correlated_duplicates(
         df=df,
-        groups=groups_corr,
+        groups=groups_corr["groups"],
         target_col=target_col,
         extra_cols=mar_cols + mcar_cols,
         verbose=False,

--- a/modules/preprocessing/final_preprocessing.py
+++ b/modules/preprocessing/final_preprocessing.py
@@ -247,7 +247,7 @@ def prepare_final_dataset(
 
     df_reduced, _, _ = drop_correlated_duplicates(
         df=df,
-        groups=groups_corr,
+        groups=groups_corr["groups"],
         target_col=target_col,
         extra_cols=mar_cols + mcar_cols,
         summary=display_info


### PR DESCRIPTION
## Summary
- ensure correlated groups passed correctly to `drop_correlated_duplicates`
- add corrected version of the EDA/preprocessing notebook using the fixed function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_6844838792f8832f8ab78972e080452b